### PR TITLE
Add cookie check and error page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This project contains a small Django application that serves a multiple-choice q
    ```bash
    pip install -r requirements.txt
    ```
-   The app uses cookie-based sessions, so you don't need to apply migrations.
+The app uses cookie-based sessions, so you don't need to apply migrations.
+Cookies must be enabled in the browser. If the test cookie set during
+initialization isn't returned, the application redirects to a page informing
+that cookies are required. This error page is served from `/cookies-required/`.
 2. Run the development server:
    ```bash
     python manage.py runserver

--- a/quiz/templates/quiz/cookies_required.html
+++ b/quiz/templates/quiz/cookies_required.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <title>Ciasteczka wymagane</title>
+</head>
+<body>
+    <h2>Ta aplikacja wymaga obsługi ciasteczek.</h2>
+    <p>Włącz ciasteczka w swojej przeglądarce i spróbuj ponownie.</p>
+    <p><a href="{% url 'index' %}">Powrót do quizu</a></p>
+</body>
+</html>

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('quiz/', views.quiz_view, name='quiz'),
     path('result/', views.result_view, name='result'),
+    path('cookies-required/', views.cookies_required, name='cookies_required'),
 ]


### PR DESCRIPTION
## Summary
- ensure test cookie set during quiz initialization
- verify cookie support in `quiz_view` and show `cookies_required` page if not
- add template for cookie warning
- route `/cookies-required/`
- document cookie requirement in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684131c90418832e9c5ff7e156187997