### PR TITLE
Remove unused root urls file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ that cookies are required. This error page is served from `/cookies-required/`.
 The quiz interface also lets you skip a question. When you choose to skip,
 the question is moved to the end of the list so you can answer it later.
 
+The project's root URL configuration lives in `quiz_django/urls.py`.
+
 ## Running tests
 
 Execute Django's test suite with:

--- a/urls.py
+++ b/urls.py
@@ -1,7 +1,0 @@
-from django.contrib import admin
-from django.urls import path, include
-
-urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include('quiz.urls')),  # ← to dodaje Twój quiz
-]


### PR DESCRIPTION
## Summary
- delete the unused top-level `urls.py`
- note the active `quiz_django/urls.py` in the README

## Testing
- `python manage.py test` *(fails: IndentationError in quiz/views.py)*

------
https://chatgpt.com/codex/tasks/task_e_6841402c84b0832e9b2a256a21e4f04d