### PR TITLE
Fix cookie handling in quiz_view

### DIFF
--- a/quiz/views.py
+++ b/quiz/views.py
@@ -41,15 +41,15 @@ def index(request):
 def quiz_view(request):
     quiz = request.session.get('quiz')
     if not quiz:
-        if not request.session.test_cookie_worked():
-            logger.debug("Test cookie failed; cookies seem to be disabled.")
-            if request.session.get(request.session.TEST_COOKIE_NAME) is not None:
-                request.session.delete_test_cookie()
-            return redirect('cookies_required')
         return redirect('index')
-            request.session.delete_test_cookie()
-            return redirect('cookies_required')
+
+    # Verify that cookies are enabled only if the test cookie is present
+    if request.session.get(request.session.TEST_COOKIE_NAME) is None:
+        return redirect('index')
+    if not request.session.test_cookie_worked():
+        logger.debug("Test cookie failed; cookies seem to be disabled.")
         request.session.delete_test_cookie()
+        return redirect('cookies_required')
 
     elapsed = timezone.now().timestamp() - quiz['start_time']
     remaining = QUIZ_DURATION_SECONDS - elapsed


### PR DESCRIPTION
## Summary
- check for the presence of the test cookie before calling `test_cookie_worked`
- if no cookie is found, redirect back to `index` to set it
- only delete the test cookie when it fails and redirect to the cookies required page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68414024df00832e98d84036df63cb71