### PR TITLE
Fix favicon without binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 db.sqlite3
+staticfiles/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ the question is moved to the end of the list so you can answer it later.
 
 The project's root URL configuration lives in `quiz_django/urls.py`.
 
+Static files are served automatically when `DEBUG=True`. In production
+you should run `collectstatic` and serve files from the directory defined by
+`STATIC_ROOT` (defaults to `staticfiles/`). The HTML templates reference
+a favicon hosted at <https://www.djangoproject.com/favicon.ico>.
+
 ## Running tests
 
 Execute Django's test suite with:

--- a/quiz/templates/quiz/cookies_required.html
+++ b/quiz/templates/quiz/cookies_required.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Ciasteczka wymagane</title>
+    <link rel="icon" href="https://www.djangoproject.com/favicon.ico">
 </head>
 <body>
     <h2>Ta aplikacja wymaga obsługi ciasteczek.</h2>

--- a/quiz/templates/quiz/index.html
+++ b/quiz/templates/quiz/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Pytanie {{ question_number }} z {{ total_questions }}</title>
+    <link rel="icon" href="https://www.djangoproject.com/favicon.ico">
 </head>
 <body>
     <!-- Reklama AdSense nad pytaniem -->

--- a/quiz/templates/quiz/result.html
+++ b/quiz/templates/quiz/result.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Wynik quizu</title>
+    <link rel="icon" href="https://www.djangoproject.com/favicon.ico">
 </head>
 <body>
     <h2>✅ Koniec quizu!</h2>

--- a/quiz_django/settings.py
+++ b/quiz_django/settings.py
@@ -115,6 +115,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/quiz_django/urls.py
+++ b/quiz_django/urls.py
@@ -16,8 +16,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('quiz.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Summary
- inline favicon reference and drop binary icon file
- enable staticfiles collection via STATIC_ROOT
- document how static files work in README

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684152aa82ec832ea6ca92456db2c61f