### PR TITLE
Add cookie check step before quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ This project contains a small Django application that serves a multiple-choice q
    pip install -r requirements.txt
    ```
 The app uses cookie-based sessions, so you don't need to apply migrations.
-Cookies must be enabled in the browser. If the test cookie set during
-initialization isn't returned, the application redirects to a page informing
-that cookies are required. This error page is served from `/cookies-required/`.
+Cookies must be enabled in the browser. At startup the `index` view sets a test
+cookie and redirects to `/check-cookie/` where the cookie is verified. If the
+test cookie isn't returned, the application redirects to `/cookies-required/` to
+inform the user that cookies must be enabled.
 2. Run the development server:
    ```bash
     python manage.py runserver

--- a/quiz/tests.py
+++ b/quiz/tests.py
@@ -2,8 +2,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 class QuizViewsTest(TestCase):
-    def test_index_redirects_to_quiz(self):
+    def test_index_redirects_to_check_cookie(self):
         response = self.client.get(reverse('index'))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('quiz'))
+        self.assertEqual(response.url, reverse('check_cookie'))
 

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('check-cookie/', views.check_cookie, name='check_cookie'),
     path('quiz/', views.quiz_view, name='quiz'),
     path('result/', views.result_view, name='result'),
     path('cookies-required/', views.cookies_required, name='cookies_required'),

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -40,6 +40,26 @@ def index(request):
             'answers': [],
             'start_time': timezone.now().timestamp()
         }
+    return redirect('check_cookie')
+
+
+def check_cookie(request):
+    """Verify that the browser accepted the test cookie before starting the quiz."""
+    global _test_cookie_pending
+    quiz = request.session.get('quiz')
+    if not quiz:
+        _test_cookie_pending = False
+        return redirect('index')
+
+    if not request.session.test_cookie_worked():
+        logger.debug("Test cookie failed; cookies seem to be disabled.")
+        if request.session.get(request.session.TEST_COOKIE_NAME) is not None:
+            request.session.delete_test_cookie()
+        _test_cookie_pending = False
+        return redirect('cookies_required')
+
+    request.session.delete_test_cookie()
+    _test_cookie_pending = False
     return redirect('quiz')
 
 


### PR DESCRIPTION
## Summary
- check that browser cookies work before starting the quiz
- update URLs and tests for the new check-cookie route
- document cookie check behaviour in README

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684159eaa654832e9dd9ad05c0993690